### PR TITLE
update: fix media mod name returned for uniquekgetmods command

### DIFF
--- a/animus/animusmod/mod_media.ino
+++ b/animus/animusmod/mod_media.ino
@@ -67,7 +67,7 @@ void mediaSerial(String input)
 {
   if (input.startsWith("uniquekgetmods"))
   {
-    Serial.print("I2C");
+    Serial.print("media");
   }
 
 }

--- a/animus/animustest2/animusmaster/mod_media.ino
+++ b/animus/animustest2/animusmaster/mod_media.ino
@@ -67,7 +67,7 @@ void mediaSerial(String input)
 {
   if (input.startsWith("uniquekgetmods"))
   {
-    Serial.print("I2C");
+    Serial.print("media");
   }
 
 }

--- a/releases/diverge-ii - Copy/diverge-ii-master/animusmaster/mod_media.ino
+++ b/releases/diverge-ii - Copy/diverge-ii-master/animusmaster/mod_media.ino
@@ -67,7 +67,7 @@ void mediaSerial(String input)
 {
   if (input.startsWith("uniquekgetmods"))
   {
-    Serial.print("I2C");
+    Serial.print("media");
   }
 
 }

--- a/releases/diverge-ii - Copy/diverge-ii-slave/animusmaster/mod_media.ino
+++ b/releases/diverge-ii - Copy/diverge-ii-slave/animusmaster/mod_media.ino
@@ -67,7 +67,7 @@ void mediaSerial(String input)
 {
   if (input.startsWith("uniquekgetmods"))
   {
-    Serial.print("I2C");
+    Serial.print("media");
   }
 
 }

--- a/releases/diverge-ii/diverge-ii-master/animusmaster/mod_media.ino
+++ b/releases/diverge-ii/diverge-ii-master/animusmaster/mod_media.ino
@@ -67,7 +67,7 @@ void mediaSerial(String input)
 {
   if (input.startsWith("uniquekgetmods"))
   {
-    Serial.print("I2C");
+    Serial.print("media");
   }
 
 }

--- a/releases/diverge-ii/diverge-ii-slave/animusmaster/mod_media.ino
+++ b/releases/diverge-ii/diverge-ii-slave/animusmaster/mod_media.ino
@@ -67,7 +67,7 @@ void mediaSerial(String input)
 {
   if (input.startsWith("uniquekgetmods"))
   {
-    Serial.print("I2C");
+    Serial.print("media");
   }
 
 }

--- a/releases/diverge-tm/diverge-tm-master/animusmaster/mod_media.ino
+++ b/releases/diverge-tm/diverge-tm-master/animusmaster/mod_media.ino
@@ -67,7 +67,7 @@ void mediaSerial(String input)
 {
   if (input.startsWith("uniquekgetmods"))
   {
-    Serial.print("I2C");
+    Serial.print("media");
   }
 
 }

--- a/releases/diverge-tm/diverge-tm-slave/animusmaster/mod_media.ino
+++ b/releases/diverge-tm/diverge-tm-slave/animusmaster/mod_media.ino
@@ -67,7 +67,7 @@ void mediaSerial(String input)
 {
   if (input.startsWith("uniquekgetmods"))
   {
-    Serial.print("I2C");
+    Serial.print("media");
   }
 
 }

--- a/releases/terminus-mini/animusmaster/mod_media.ino
+++ b/releases/terminus-mini/animusmaster/mod_media.ino
@@ -67,7 +67,7 @@ void mediaSerial(String input)
 {
   if (input.startsWith("uniquekgetmods"))
   {
-    Serial.print("I2C");
+    Serial.print("media");
   }
 
 }


### PR DESCRIPTION
In the media mod, uniquekgetmods returns "I2C" instead of "media".

This minor patch changes the printed text to "media", in order to match the mod name.