### PR TITLE
Adjusting the logical and usage maximums to accommodate all keyboard …

### DIFF
--- a/animus/AnimusKeyboard.cpp
+++ b/animus/AnimusKeyboard.cpp
@@ -51,11 +51,11 @@ static const uint8_t _hidReportDescriptor[] PROGMEM = {
   0x95, 0x06,                    //   REPORT_COUNT (6)
     0x75, 0x08,                    //   REPORT_SIZE (8)
     0x15, 0x00,                    //   LOGICAL_MINIMUM (0)
-    0x25, 0x65,                    //   LOGICAL_MAXIMUM (101)
+    0x25, 0xdd,                    //   LOGICAL_MAXIMUM (221)
     0x05, 0x07,                    //   USAGE_PAGE (Keyboard)
 
   0x19, 0x00,                    //   USAGE_MINIMUM (Reserved (no event indicated))
-    0x29, 0x65,                    //   USAGE_MAXIMUM (Keyboard Application)
+    0x29, 0xdd,                    //   USAGE_MAXIMUM (Keyboard Application)
     0x81, 0x00,                    //   INPUT (Data,Ary,Abs)
     0xc0,                          // END_COLLECTION
 };

--- a/keyboard-specific-builds/diverge-1/diverge-left/animus/AnimusKeyboard.cpp
+++ b/keyboard-specific-builds/diverge-1/diverge-left/animus/AnimusKeyboard.cpp
@@ -51,11 +51,11 @@ static const uint8_t _hidReportDescriptor[] PROGMEM = {
   0x95, 0x06,                    //   REPORT_COUNT (6)
     0x75, 0x08,                    //   REPORT_SIZE (8)
     0x15, 0x00,                    //   LOGICAL_MINIMUM (0)
-    0x25, 0x65,                    //   LOGICAL_MAXIMUM (101)
+    0x25, 0xdd,                    //   LOGICAL_MAXIMUM (221)
     0x05, 0x07,                    //   USAGE_PAGE (Keyboard)
 
   0x19, 0x00,                    //   USAGE_MINIMUM (Reserved (no event indicated))
-    0x29, 0x65,                    //   USAGE_MAXIMUM (Keyboard Application)
+    0x29, 0xdd,                    //   USAGE_MAXIMUM (Keyboard Application)
     0x81, 0x00,                    //   INPUT (Data,Ary,Abs)
     0xc0,                          // END_COLLECTION
 };

--- a/keyboard-specific-builds/diverge-1/diverge-right/animus/AnimusKeyboard.cpp
+++ b/keyboard-specific-builds/diverge-1/diverge-right/animus/AnimusKeyboard.cpp
@@ -51,11 +51,11 @@ static const uint8_t _hidReportDescriptor[] PROGMEM = {
   0x95, 0x06,                    //   REPORT_COUNT (6)
     0x75, 0x08,                    //   REPORT_SIZE (8)
     0x15, 0x00,                    //   LOGICAL_MINIMUM (0)
-    0x25, 0x65,                    //   LOGICAL_MAXIMUM (101)
+    0x25, 0xdd,                    //   LOGICAL_MAXIMUM (221)
     0x05, 0x07,                    //   USAGE_PAGE (Keyboard)
 
   0x19, 0x00,                    //   USAGE_MINIMUM (Reserved (no event indicated))
-    0x29, 0x65,                    //   USAGE_MAXIMUM (Keyboard Application)
+    0x29, 0xdd,                    //   USAGE_MAXIMUM (Keyboard Application)
     0x81, 0x00,                    //   INPUT (Data,Ary,Abs)
     0xc0,                          // END_COLLECTION
 };

--- a/keyboard-specific-builds/diverge-2/diverge-2-master/animus/AnimusKeyboard.cpp
+++ b/keyboard-specific-builds/diverge-2/diverge-2-master/animus/AnimusKeyboard.cpp
@@ -51,11 +51,11 @@ static const uint8_t _hidReportDescriptor[] PROGMEM = {
   0x95, 0x06,                    //   REPORT_COUNT (6)
     0x75, 0x08,                    //   REPORT_SIZE (8)
     0x15, 0x00,                    //   LOGICAL_MINIMUM (0)
-    0x25, 0x65,                    //   LOGICAL_MAXIMUM (101)
+    0x25, 0xdd,                    //   LOGICAL_MAXIMUM (221)
     0x05, 0x07,                    //   USAGE_PAGE (Keyboard)
 
   0x19, 0x00,                    //   USAGE_MINIMUM (Reserved (no event indicated))
-    0x29, 0x65,                    //   USAGE_MAXIMUM (Keyboard Application)
+    0x29, 0xdd,                    //   USAGE_MAXIMUM (Keyboard Application)
     0x81, 0x00,                    //   INPUT (Data,Ary,Abs)
     0xc0,                          // END_COLLECTION
 };

--- a/keyboard-specific-builds/diverge-2/diverge-2-slave/animus/AnimusKeyboard.cpp
+++ b/keyboard-specific-builds/diverge-2/diverge-2-slave/animus/AnimusKeyboard.cpp
@@ -51,11 +51,11 @@ static const uint8_t _hidReportDescriptor[] PROGMEM = {
   0x95, 0x06,                    //   REPORT_COUNT (6)
     0x75, 0x08,                    //   REPORT_SIZE (8)
     0x15, 0x00,                    //   LOGICAL_MINIMUM (0)
-    0x25, 0x65,                    //   LOGICAL_MAXIMUM (101)
+    0x25, 0xdd,                    //   LOGICAL_MAXIMUM (221)
     0x05, 0x07,                    //   USAGE_PAGE (Keyboard)
 
   0x19, 0x00,                    //   USAGE_MINIMUM (Reserved (no event indicated))
-    0x29, 0x65,                    //   USAGE_MAXIMUM (Keyboard Application)
+    0x29, 0xdd,                    //   USAGE_MAXIMUM (Keyboard Application)
     0x81, 0x00,                    //   INPUT (Data,Ary,Abs)
     0xc0,                          // END_COLLECTION
 };

--- a/keyboard-specific-builds/diverge-3/diverge-3-master/animus/AnimusKeyboard.cpp
+++ b/keyboard-specific-builds/diverge-3/diverge-3-master/animus/AnimusKeyboard.cpp
@@ -51,11 +51,11 @@ static const uint8_t _hidReportDescriptor[] PROGMEM = {
   0x95, 0x06,                    //   REPORT_COUNT (6)
     0x75, 0x08,                    //   REPORT_SIZE (8)
     0x15, 0x00,                    //   LOGICAL_MINIMUM (0)
-    0x25, 0x65,                    //   LOGICAL_MAXIMUM (101)
+    0x25, 0xdd,                    //   LOGICAL_MAXIMUM (221)
     0x05, 0x07,                    //   USAGE_PAGE (Keyboard)
 
   0x19, 0x00,                    //   USAGE_MINIMUM (Reserved (no event indicated))
-    0x29, 0x65,                    //   USAGE_MAXIMUM (Keyboard Application)
+    0x29, 0xdd,                    //   USAGE_MAXIMUM (Keyboard Application)
     0x81, 0x00,                    //   INPUT (Data,Ary,Abs)
     0xc0,                          // END_COLLECTION
 };

--- a/keyboard-specific-builds/diverge-3/diverge-3-slave/animus/AnimusKeyboard.cpp
+++ b/keyboard-specific-builds/diverge-3/diverge-3-slave/animus/AnimusKeyboard.cpp
@@ -51,11 +51,11 @@ static const uint8_t _hidReportDescriptor[] PROGMEM = {
   0x95, 0x06,                    //   REPORT_COUNT (6)
     0x75, 0x08,                    //   REPORT_SIZE (8)
     0x15, 0x00,                    //   LOGICAL_MINIMUM (0)
-    0x25, 0x65,                    //   LOGICAL_MAXIMUM (101)
+    0x25, 0xdd,                    //   LOGICAL_MAXIMUM (221)
     0x05, 0x07,                    //   USAGE_PAGE (Keyboard)
 
   0x19, 0x00,                    //   USAGE_MINIMUM (Reserved (no event indicated))
-    0x29, 0x65,                    //   USAGE_MAXIMUM (Keyboard Application)
+    0x29, 0xdd,                    //   USAGE_MAXIMUM (Keyboard Application)
     0x81, 0x00,                    //   INPUT (Data,Ary,Abs)
     0xc0,                          // END_COLLECTION
 };

--- a/keyboard-specific-builds/diverge-tm-2/diverge-tm-2-master/animus/AnimusKeyboard.cpp
+++ b/keyboard-specific-builds/diverge-tm-2/diverge-tm-2-master/animus/AnimusKeyboard.cpp
@@ -51,11 +51,11 @@ static const uint8_t _hidReportDescriptor[] PROGMEM = {
   0x95, 0x06,                    //   REPORT_COUNT (6)
     0x75, 0x08,                    //   REPORT_SIZE (8)
     0x15, 0x00,                    //   LOGICAL_MINIMUM (0)
-    0x25, 0x65,                    //   LOGICAL_MAXIMUM (101)
+    0x25, 0xdd,                    //   LOGICAL_MAXIMUM (221)
     0x05, 0x07,                    //   USAGE_PAGE (Keyboard)
 
   0x19, 0x00,                    //   USAGE_MINIMUM (Reserved (no event indicated))
-    0x29, 0x65,                    //   USAGE_MAXIMUM (Keyboard Application)
+    0x29, 0xdd,                    //   USAGE_MAXIMUM (Keyboard Application)
     0x81, 0x00,                    //   INPUT (Data,Ary,Abs)
     0xc0,                          // END_COLLECTION
 };

--- a/keyboard-specific-builds/diverge-tm-2/diverge-tm-2-slave/animus/AnimusKeyboard.cpp
+++ b/keyboard-specific-builds/diverge-tm-2/diverge-tm-2-slave/animus/AnimusKeyboard.cpp
@@ -51,11 +51,11 @@ static const uint8_t _hidReportDescriptor[] PROGMEM = {
   0x95, 0x06,                    //   REPORT_COUNT (6)
     0x75, 0x08,                    //   REPORT_SIZE (8)
     0x15, 0x00,                    //   LOGICAL_MINIMUM (0)
-    0x25, 0x65,                    //   LOGICAL_MAXIMUM (101)
+    0x25, 0xdd,                    //   LOGICAL_MAXIMUM (221)
     0x05, 0x07,                    //   USAGE_PAGE (Keyboard)
 
   0x19, 0x00,                    //   USAGE_MINIMUM (Reserved (no event indicated))
-    0x29, 0x65,                    //   USAGE_MAXIMUM (Keyboard Application)
+    0x29, 0xdd,                    //   USAGE_MAXIMUM (Keyboard Application)
     0x81, 0x00,                    //   INPUT (Data,Ary,Abs)
     0xc0,                          // END_COLLECTION
 };

--- a/keyboard-specific-builds/diverge-tm/diverge-tm-master/animus/AnimusKeyboard.cpp
+++ b/keyboard-specific-builds/diverge-tm/diverge-tm-master/animus/AnimusKeyboard.cpp
@@ -51,11 +51,11 @@ static const uint8_t _hidReportDescriptor[] PROGMEM = {
   0x95, 0x06,                    //   REPORT_COUNT (6)
     0x75, 0x08,                    //   REPORT_SIZE (8)
     0x15, 0x00,                    //   LOGICAL_MINIMUM (0)
-    0x25, 0x65,                    //   LOGICAL_MAXIMUM (101)
+    0x25, 0xdd,                    //   LOGICAL_MAXIMUM (221)
     0x05, 0x07,                    //   USAGE_PAGE (Keyboard)
 
   0x19, 0x00,                    //   USAGE_MINIMUM (Reserved (no event indicated))
-    0x29, 0x65,                    //   USAGE_MAXIMUM (Keyboard Application)
+    0x29, 0xdd,                    //   USAGE_MAXIMUM (Keyboard Application)
     0x81, 0x00,                    //   INPUT (Data,Ary,Abs)
     0xc0,                          // END_COLLECTION
 };

--- a/keyboard-specific-builds/diverge-tm/diverge-tm-slave/animus/AnimusKeyboard.cpp
+++ b/keyboard-specific-builds/diverge-tm/diverge-tm-slave/animus/AnimusKeyboard.cpp
@@ -51,11 +51,11 @@ static const uint8_t _hidReportDescriptor[] PROGMEM = {
   0x95, 0x06,                    //   REPORT_COUNT (6)
     0x75, 0x08,                    //   REPORT_SIZE (8)
     0x15, 0x00,                    //   LOGICAL_MINIMUM (0)
-    0x25, 0x65,                    //   LOGICAL_MAXIMUM (101)
+    0x25, 0xdd,                    //   LOGICAL_MAXIMUM (221)
     0x05, 0x07,                    //   USAGE_PAGE (Keyboard)
 
   0x19, 0x00,                    //   USAGE_MINIMUM (Reserved (no event indicated))
-    0x29, 0x65,                    //   USAGE_MAXIMUM (Keyboard Application)
+    0x29, 0xdd,                    //   USAGE_MAXIMUM (Keyboard Application)
     0x81, 0x00,                    //   INPUT (Data,Ary,Abs)
     0xc0,                          // END_COLLECTION
 };

--- a/keyboard-specific-builds/felix/animus/AnimusKeyboard.cpp
+++ b/keyboard-specific-builds/felix/animus/AnimusKeyboard.cpp
@@ -51,11 +51,11 @@ static const uint8_t _hidReportDescriptor[] PROGMEM = {
   0x95, 0x06,                    //   REPORT_COUNT (6)
     0x75, 0x08,                    //   REPORT_SIZE (8)
     0x15, 0x00,                    //   LOGICAL_MINIMUM (0)
-    0x25, 0x65,                    //   LOGICAL_MAXIMUM (101)
+    0x25, 0xdd,                    //   LOGICAL_MAXIMUM (221)
     0x05, 0x07,                    //   USAGE_PAGE (Keyboard)
 
   0x19, 0x00,                    //   USAGE_MINIMUM (Reserved (no event indicated))
-    0x29, 0x65,                    //   USAGE_MAXIMUM (Keyboard Application)
+    0x29, 0xdd,                    //   USAGE_MAXIMUM (Keyboard Application)
     0x81, 0x00,                    //   INPUT (Data,Ary,Abs)
     0xc0,                          // END_COLLECTION
 };

--- a/keyboard-specific-builds/lets-split-2/lets-split-v2-test1/animus/AnimusKeyboard.cpp
+++ b/keyboard-specific-builds/lets-split-2/lets-split-v2-test1/animus/AnimusKeyboard.cpp
@@ -51,11 +51,11 @@ static const uint8_t _hidReportDescriptor[] PROGMEM = {
   0x95, 0x06,                    //   REPORT_COUNT (6)
     0x75, 0x08,                    //   REPORT_SIZE (8)
     0x15, 0x00,                    //   LOGICAL_MINIMUM (0)
-    0x25, 0x65,                    //   LOGICAL_MAXIMUM (101)
+    0x25, 0xdd,                    //   LOGICAL_MAXIMUM (221)
     0x05, 0x07,                    //   USAGE_PAGE (Keyboard)
 
   0x19, 0x00,                    //   USAGE_MINIMUM (Reserved (no event indicated))
-    0x29, 0x65,                    //   USAGE_MAXIMUM (Keyboard Application)
+    0x29, 0xdd,                    //   USAGE_MAXIMUM (Keyboard Application)
     0x81, 0x00,                    //   INPUT (Data,Ary,Abs)
     0xc0,                          // END_COLLECTION
 };

--- a/keyboard-specific-builds/lets-split-2/lets-split-v2-test2/animus/AnimusKeyboard.cpp
+++ b/keyboard-specific-builds/lets-split-2/lets-split-v2-test2/animus/AnimusKeyboard.cpp
@@ -51,11 +51,11 @@ static const uint8_t _hidReportDescriptor[] PROGMEM = {
   0x95, 0x06,                    //   REPORT_COUNT (6)
     0x75, 0x08,                    //   REPORT_SIZE (8)
     0x15, 0x00,                    //   LOGICAL_MINIMUM (0)
-    0x25, 0x65,                    //   LOGICAL_MAXIMUM (101)
+    0x25, 0xdd,                    //   LOGICAL_MAXIMUM (221)
     0x05, 0x07,                    //   USAGE_PAGE (Keyboard)
 
   0x19, 0x00,                    //   USAGE_MINIMUM (Reserved (no event indicated))
-    0x29, 0x65,                    //   USAGE_MAXIMUM (Keyboard Application)
+    0x29, 0xdd,                    //   USAGE_MAXIMUM (Keyboard Application)
     0x81, 0x00,                    //   INPUT (Data,Ary,Abs)
     0xc0,                          // END_COLLECTION
 };

--- a/keyboard-specific-builds/terminus-2/terminus-2-master/animus/AnimusKeyboard.cpp
+++ b/keyboard-specific-builds/terminus-2/terminus-2-master/animus/AnimusKeyboard.cpp
@@ -51,11 +51,11 @@ static const uint8_t _hidReportDescriptor[] PROGMEM = {
   0x95, 0x06,                    //   REPORT_COUNT (6)
     0x75, 0x08,                    //   REPORT_SIZE (8)
     0x15, 0x00,                    //   LOGICAL_MINIMUM (0)
-    0x25, 0x65,                    //   LOGICAL_MAXIMUM (101)
+    0x25, 0xdd,                    //   LOGICAL_MAXIMUM (221)
     0x05, 0x07,                    //   USAGE_PAGE (Keyboard)
 
   0x19, 0x00,                    //   USAGE_MINIMUM (Reserved (no event indicated))
-    0x29, 0x65,                    //   USAGE_MAXIMUM (Keyboard Application)
+    0x29, 0xdd,                    //   USAGE_MAXIMUM (Keyboard Application)
     0x81, 0x00,                    //   INPUT (Data,Ary,Abs)
     0xc0,                          // END_COLLECTION
 };

--- a/keyboard-specific-builds/terminus-2/terminus-2-slave/animus/AnimusKeyboard.cpp
+++ b/keyboard-specific-builds/terminus-2/terminus-2-slave/animus/AnimusKeyboard.cpp
@@ -51,11 +51,11 @@ static const uint8_t _hidReportDescriptor[] PROGMEM = {
   0x95, 0x06,                    //   REPORT_COUNT (6)
     0x75, 0x08,                    //   REPORT_SIZE (8)
     0x15, 0x00,                    //   LOGICAL_MINIMUM (0)
-    0x25, 0x65,                    //   LOGICAL_MAXIMUM (101)
+    0x25, 0xdd,                    //   LOGICAL_MAXIMUM (221)
     0x05, 0x07,                    //   USAGE_PAGE (Keyboard)
 
   0x19, 0x00,                    //   USAGE_MINIMUM (Reserved (no event indicated))
-    0x29, 0x65,                    //   USAGE_MAXIMUM (Keyboard Application)
+    0x29, 0xdd,                    //   USAGE_MAXIMUM (Keyboard Application)
     0x81, 0x00,                    //   INPUT (Data,Ary,Abs)
     0xc0,                          // END_COLLECTION
 };

--- a/keyboard-specific-builds/terminus-mini-2/animus/AnimusKeyboard.cpp
+++ b/keyboard-specific-builds/terminus-mini-2/animus/AnimusKeyboard.cpp
@@ -51,11 +51,11 @@ static const uint8_t _hidReportDescriptor[] PROGMEM = {
   0x95, 0x06,                    //   REPORT_COUNT (6)
     0x75, 0x08,                    //   REPORT_SIZE (8)
     0x15, 0x00,                    //   LOGICAL_MINIMUM (0)
-    0x25, 0x65,                    //   LOGICAL_MAXIMUM (101)
+    0x25, 0xdd,                    //   LOGICAL_MAXIMUM (221)
     0x05, 0x07,                    //   USAGE_PAGE (Keyboard)
 
   0x19, 0x00,                    //   USAGE_MINIMUM (Reserved (no event indicated))
-    0x29, 0x65,                    //   USAGE_MAXIMUM (Keyboard Application)
+    0x29, 0xdd,                    //   USAGE_MAXIMUM (Keyboard Application)
     0x81, 0x00,                    //   INPUT (Data,Ary,Abs)
     0xc0,                          // END_COLLECTION
 };

--- a/keyboard-specific-builds/terminus-mini/animus/AnimusKeyboard.cpp
+++ b/keyboard-specific-builds/terminus-mini/animus/AnimusKeyboard.cpp
@@ -51,11 +51,11 @@ static const uint8_t _hidReportDescriptor[] PROGMEM = {
   0x95, 0x06,                    //   REPORT_COUNT (6)
     0x75, 0x08,                    //   REPORT_SIZE (8)
     0x15, 0x00,                    //   LOGICAL_MINIMUM (0)
-    0x25, 0x65,                    //   LOGICAL_MAXIMUM (101)
+    0x25, 0xdd,                    //   LOGICAL_MAXIMUM (221)
     0x05, 0x07,                    //   USAGE_PAGE (Keyboard)
 
   0x19, 0x00,                    //   USAGE_MINIMUM (Reserved (no event indicated))
-    0x29, 0x65,                    //   USAGE_MAXIMUM (Keyboard Application)
+    0x29, 0xdd,                    //   USAGE_MAXIMUM (Keyboard Application)
     0x81, 0x00,                    //   INPUT (Data,Ary,Abs)
     0xc0,                          // END_COLLECTION
 };

--- a/tools/libraries/AnimusHID/src/AnimusKeyboard.cpp
+++ b/tools/libraries/AnimusHID/src/AnimusKeyboard.cpp
@@ -52,11 +52,11 @@ static const uint8_t _hidReportDescriptor[] PROGMEM =
   0x95, 0x06,                    //   REPORT_COUNT (6)
   0x75, 0x08,                    //   REPORT_SIZE (8)
   0x15, 0x00,                    //   LOGICAL_MINIMUM (0)
-  0x25, 0x65,                    //   LOGICAL_MAXIMUM (101)
+  0x25, 0xdd,                    //   LOGICAL_MAXIMUM (221)
   0x05, 0x07,                    //   USAGE_PAGE (Keyboard)
 
   0x19, 0x00,                    //   USAGE_MINIMUM (Reserved (no event indicated))
-  0x29, 0x65,                    //   USAGE_MAXIMUM (Keyboard Application)
+  0x29, 0xdd,                    //   USAGE_MAXIMUM (Keyboard Application)
   0x81, 0x00,                    //   INPUT (Data,Ary,Abs)
   0xc0,                          // END_COLLECTION
   //  Keyboard2
@@ -81,11 +81,11 @@ static const uint8_t _hidReportDescriptor[] PROGMEM =
   0x95, 0x06,                    //   REPORT_COUNT (6)
   0x75, 0x08,                    //   REPORT_SIZE (8)
   0x15, 0x00,                    //   LOGICAL_MINIMUM (0)
-  0x25, 0x65,                    //   LOGICAL_MAXIMUM (101)
+  0x25, 0xdd,                    //   LOGICAL_MAXIMUM (221)
   0x05, 0x07,                    //   USAGE_PAGE (Keyboard)
 
   0x19, 0x00,                    //   USAGE_MINIMUM (Reserved (no event indicated))
-  0x29, 0x65,                    //   USAGE_MAXIMUM (Keyboard Application)
+  0x29, 0xdd,                    //   USAGE_MAXIMUM (Keyboard Application)
   0x81, 0x00,                    //   INPUT (Data,Ary,Abs)
   0xc0,                          // END_COLLECTION
 
@@ -112,11 +112,11 @@ static const uint8_t _hidReportDescriptor[] PROGMEM =
   0x95, 0x06,                    //   REPORT_COUNT (6)
   0x75, 0x08,                    //   REPORT_SIZE (8)
   0x15, 0x00,                    //   LOGICAL_MINIMUM (0)
-  0x25, 0x65,                    //   LOGICAL_MAXIMUM (101)
+  0x25, 0xdd,                    //   LOGICAL_MAXIMUM (221)
   0x05, 0x07,                    //   USAGE_PAGE (Keyboard)
 
   0x19, 0x00,                    //   USAGE_MINIMUM (Reserved (no event indicated))
-  0x29, 0x65,                    //   USAGE_MAXIMUM (Keyboard Application)
+  0x29, 0xdd,                    //   USAGE_MAXIMUM (Keyboard Application)
   0x81, 0x00,                    //   INPUT (Data,Ary,Abs)
   0xc0,                          // END_COLLECTION
 };


### PR DESCRIPTION
…key codes.

According to the HID Usage Tables (ver 1.12), key codes with a usage id
up to xDD could be utilized by certain operating systems, depending on
drivers. In order to allow these keys (above the standard 101 keys or
x65), two tags were modified: (1) the local USAGE_MAXIMUM and (2) the
global LOGICAL_MAXIMUM. These were modified from x65 to xdd.

As a note, the HID usage tables have reserved key code ids 165-175,
222-223, and 232-65535.