### PR TITLE
add mouse buttons as type 99

### DIFF
--- a/keyboard-specific-builds/diverge-2/diverge-2-master/animus/animus.ino
+++ b/keyboard-specific-builds/diverge-2/diverge-2-master/animus/animus.ino
@@ -1,3 +1,5 @@
+#include "Mouse.h"
+
 #define builder_row 5
 #define builder_col 8
 #define builder_kbname "Diverge 2 Master"

--- a/keyboard-specific-builds/diverge-2/diverge-2-master/animus/animus_main.ino
+++ b/keyboard-specific-builds/diverge-2/diverge-2-master/animus/animus_main.ino
@@ -30,6 +30,7 @@ int BaudRate = 19200;
 void setup()
 {
   Keyboard.begin();
+  Mouse.begin();
   Serial.begin(BaudRate);
   NKROStartup();
   ModStartup();
@@ -190,6 +191,11 @@ void PressKey(char val, byte type)
       PressKey(226, 0);
       PressKey(val, 0);
     }
+    else if (type == 99)
+    {
+      // mouse buttons
+      Mouse.press(val);
+    }
   }
 
   NKROKeyDown(val, type);
@@ -270,6 +276,11 @@ void ReleaseKey(char val, byte type)
       ReleaseKey(225, 0);
       ReleaseKey(226, 0);
       ReleaseKey(val, 0);
+    }
+    else if (type == 99)
+    {
+      // mouse buttons
+      Mouse.release(val);
     }
   }
   NKROKeyUp(val, type);


### PR DESCRIPTION
This is more of a proof-of-concept than something that I expect to be merged as-is, but I wanted your feedback before I put any more work into it.

This will have to be moved up into the non-keyboard-specific directories.

Open questions: Do you want this to be a module?  Should Mouse.press() calls go through an intermediary function like KeyPress() does for Keyboard.press()?  Do you want the #include Mouse.h in a different file?

Thanks!