### PR TITLE
Improve debounce handling

### DIFF
--- a/animus-2/animus/animus_main.ino
+++ b/animus-2/animus/animus_main.ino
@@ -71,8 +71,8 @@ void loop()
             LayerState[j][i] = TempLayer;
             ModPrePress(GetValEEPROM(j, i, TempLayer), GetTypeEEPROM(j, i, TempLayer));
             PressKey(GetValEEPROM(j, i, TempLayer), GetTypeEEPROM(j, i, TempLayer));
-            KeyStateCoolDown[j][i] = 255;
           }
+          KeyStateCoolDown[j][i] = 255;
         }
         else if (KeyState[j][i] == LOW) // if key is up
         {


### PR DESCRIPTION
KeyStateCoolDown is reset on every key down event instead of only when a key press event would trigger. This fixes my key chatter issue where I think my keys were oscillating rapidly between up/down states over a period of time that could overlap with the cooldown mechanism in such a way as to trigger multiple key presses in a short period of time.

By resetting the cooldown on every key down state, oscillations are suppressed because the key up and refresh delays to only start elapsing once the key has stabilized in the up state.